### PR TITLE
Feature/nokogiri version

### DIFF
--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -16,7 +16,7 @@
 #
 
 name "nokogiri"
-default_version "1.6.1"
+default_version "1.5.11"
 
 if platform == 'windows'
   dependency "ruby-windows"


### PR DESCRIPTION
Imported from opscode/omnibus-software and changed version to 1.5.11... no other changes. This is needed for the version of fog that we are shipping with the packages.
