### PR TITLE
CDAP has server directory, too... allow for this for Coopr

### DIFF
--- a/config/software/coopr-ui.rb
+++ b/config/software/coopr-ui.rb
@@ -22,7 +22,7 @@ build do
   command "cd #{project_dir}/coopr-ui; #{node} #{project_dir}/coopr-ui/node_modules/gulp/bin/gulp.js distribute"
 
   copy "#{project_dir}/coopr-ui/dist*", "#{install_dir}"
-  copy "#{project_dir}/coopr-ui/server.js", "#{install_dir}"
+  copy "#{project_dir}/coopr-ui/server*", "#{install_dir}"
   copy "#{project_dir}/coopr-ui/package.json", "#{install_dir}"
 
   command "cd #{install_dir}; #{npm} install --production"


### PR DESCRIPTION
After discussion with @gaarf I was informed that CDAP has split `server.js` into a top-level file and several files under a `server` directory. This will likely happen with Coopr, too, so changing this now to future-proof builds.