### PR TITLE
Install coopr-templates/bin under server/templates

### DIFF
--- a/config/software/coopr-server.rb
+++ b/config/software/coopr-server.rb
@@ -11,7 +11,7 @@ build do
   copy "#{project_dir}/coopr-server/bin/*", "#{install_dir}/bin"
   copy "#{project_dir}/coopr-docs/licenses", "#{install_dir}"
   copy "#{project_dir}/coopr-server/distribution", "#{install_dir}"
-  %w(clustertemplates hardwaretypes imagetypes providers services).each do |dir|
+  %w(bin clustertemplates hardwaretypes imagetypes providers services).each do |dir|
     copy "#{project_dir}/coopr-templates/#{dir}", "#{install_dir}/templates"
   end
   copy "#{project_dir}/coopr-server/templates/*", "#{install_dir}/templates"


### PR DESCRIPTION
This gives us our helper script for installing templates shipped with the package.
