### PR TITLE
Update fog for caskdata/coopr-provisioner#99

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 # Use Berkshelf for resolving cookbook dependencies
 gem 'berkshelf', '~> 3.0'
 gem 'hashie', '< 3.0'
+gem 'varia_model', '< 0.5' # 0.5+ require Ruby 2.0
 
 # Install omnibus software
 gem 'omnibus', '~> 3.1'

--- a/config/software/coopr-provisioner.rb
+++ b/config/software/coopr-provisioner.rb
@@ -9,7 +9,7 @@ source :git => 'git://github.com/caskdata/coopr-provisioner.git'
 # relative_path 'coopr-provisioner'
 
 build do
-  gem 'install fog --no-rdoc --no-ri --version 1.26.0'
+  gem 'install fog --no-rdoc --no-ri --version 1.36.0'
   gem 'install sinatra --no-rdoc --no-ri --version 1.4.5'
   gem 'install thin --no-rdoc --no-ri --version 1.6.2'
   gem 'install rest_client --no-rdoc --no-ri --version 1.7.3'


### PR DESCRIPTION
This is needed to build the omnibus packages with the correct version of the fog Gem.
