### PR TITLE
Switch to using bundler to install Ruby Gems

### DIFF
--- a/config/software/coopr-provisioner.rb
+++ b/config/software/coopr-provisioner.rb
@@ -9,12 +9,7 @@ source :git => 'git://github.com/caskdata/coopr-provisioner.git'
 # relative_path 'coopr-provisioner'
 
 build do
-  gem 'install fog --no-rdoc --no-ri --version 1.36.0'
-  gem 'install sinatra --no-rdoc --no-ri --version 1.4.5'
-  gem 'install thin --no-rdoc --no-ri --version 1.6.2'
-  gem 'install rest_client --no-rdoc --no-ri --version 1.7.3'
-  gem 'install google-api-client --no-rdoc --no-ri --version 0.7.1'
-  gem 'install deep_merge --no-rdoc --no-ri --version 1.0.1'
+  bundle 'install --jobs 7 --without test'
   mkdir install_dir
   copy "#{project_dir}/*", "#{install_dir}"
   command "chmod +x #{install_dir}/bin/*"


### PR DESCRIPTION
This prevents us from needing to modify Gem versions in Omnibus to match what's in Coopr! Yaaay!
