### PR TITLE
Only remove install_dir contents

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,6 +74,7 @@ Vagrant.configure('2') do |config|
   config.vm.provision :shell, :inline => <<-BUNDLER
     cd #{guest_project_path}
     gem install bundler --no-rdoc --no-ri
+    chown -R vagrant /opt
     su vagrant -c "bundle install --binstubs"
   BUNDLER
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,6 +81,7 @@ Vagrant.configure('2') do |config|
     config.vm.provision :shell, :inline => <<-OMNIBUS_BUILD
       export PATH=/usr/local/bin:/usr/local/maven-3.1.1/bin:$PATH
       cd #{guest_project_path}
+      mkdir -p /opt/coopr && chown vagrant /opt/coopr
       su vagrant -c "bin/omnibus build #{project_name}"
       rm -rf /opt/coopr
     OMNIBUS_BUILD

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,9 +81,8 @@ Vagrant.configure('2') do |config|
     config.vm.provision :shell, :inline => <<-OMNIBUS_BUILD
       export PATH=/usr/local/bin:/usr/local/maven-3.1.1/bin:$PATH
       cd #{guest_project_path}
-      mkdir -p /opt/coopr && chown vagrant /opt/coopr
       su vagrant -c "bin/omnibus build #{project_name}"
-      rm -rf /opt/coopr
+      rm -rf /opt/coopr/*
     OMNIBUS_BUILD
   end
 end


### PR DESCRIPTION
This fixes a bug introduced in #60 where the omnibus install_dir wasn't writable by build_user, as this is normally handled by the omnibus cookbook, and we wipe install_dir between omnibus runs.

Fix by just removing install_dir contents, not install_dir itself.
