### PR TITLE
Create Dockerfiles for building in Docker

### DIFF
--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -1,0 +1,74 @@
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+FROM centos:6
+MAINTAINER Cask Data <ops@cask.co>
+
+# Copy files
+# Setup ENV
+# Install Chef
+# Setup chef dir
+# Install/run omnibus, java, and maven cookbooks
+
+COPY . /var/tmp/coopr-build
+
+ENV PATH /usr/local/bin:${PATH}
+ENV COOPR_BUILD_PROJECTS coopr-cli coopr-provisioner coopr-server coopr-ui
+
+RUN useradd -m coopr && \
+  yum makecache && \
+  yum install -y \
+    curl \
+    git \
+    python && \
+  curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.4.3 && \
+  mkdir -p /var/chef/cookbooks && \
+  cd /var/chef/cookbooks && \
+  touch .gitignore && git init && git add .gitignore && git commit -m 'Initial commit' && \
+  knife cookbook site install maven 1.1.0 && \
+  knife cookbook site install apt 2.4.0 && \
+  knife cookbook site install build-essential 1.4.4 && \
+  knife cookbook site install git 3.1.0 && \
+  knife cookbook site install homebrew 1.9.0 && \
+  knife cookbook site install pkgin 0.4.0 && \
+  knife cookbook site install pkgutil 0.0.3 && \
+  knife cookbook site install rbenv 1.7.1 && \
+  knife cookbook site install windows 1.34.2 && \
+  knife cookbook site install wix 1.1.0 && \
+  knife cookbook site install yum-epel 0.4.0 && \
+  knife cookbook site download 7-zip --force && \
+  for tb in maven apt build-essential git homebrew pkgin pkgutil rbenv windows wix yum-epel 7-zip; do \
+    tar xf ${tb}*.tar.gz ; \
+    rm -f ${tb}*.tar.gz ; \
+  done && \
+  echo "name 'pkgin'" >> pkgin/metadata.rb && \
+  git commit -am "HACK: Add name to pkgin's metadata" && \
+  echo "name 'pkgutil'" >> pkgutil/metadata.rb && \
+  git commit -am "HACK: Add name to pkgutil's metadata" && \
+  knife cookbook site install omnibus 1.2.4 --skip-dependencies && \
+  rm -f *.tar.gz && \
+  mkdir -p /var/tmp/coopr-build && \
+  chown -R coopr /var/tmp/coopr-build && \
+  cd /var/tmp/coopr-build && \
+  chef-solo -j /var/tmp/coopr-build/chef.json -o 'recipe[omnibus],recipe[maven]' && \
+  gem install bundler --no-rdoc --no-ri && \
+  chown -R coopr /opt && \
+  su coopr -c "bundle install --binstubs" && \
+  su coopr -c "git config --global user.email 'ops@cask.co' && git config --global user.name 'Cask Ops'" && \
+  for project in ${COOPR_BUILD_PROJECTS} ; do \
+    su coopr -c "bin/omnibus build ${project}" ; \
+    rm -rf /opt/coopr ; \
+  done

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -1,0 +1,74 @@
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Cask is a trademark of Cask Data, Inc. All rights reserved.
+
+FROM ubuntu:12.04
+MAINTAINER Cask Data <ops@cask.co>
+
+# Copy files
+# Setup ENV
+# Install Chef
+# Setup chef dir
+# Install/run omnibus, java, and maven cookbooks
+
+COPY . /var/tmp/coopr-build
+
+ENV PATH /usr/local/bin:${PATH}
+ENV COOPR_BUILD_PROJECTS coopr-cli coopr-provisioner coopr-server coopr-ui
+
+RUN useradd -m coopr && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    python2.7 && \
+  curl -vL http://chef.io/chef/install.sh | bash -s -- -v 12.4.3 && \
+  mkdir -p /var/chef/cookbooks && \
+  cd /var/chef/cookbooks && \
+  touch .gitignore && git init && git add .gitignore && git commit -m 'Initial commit' && \
+  knife cookbook site install maven 1.1.0 && \
+  knife cookbook site install apt 2.4.0 && \
+  knife cookbook site install build-essential 1.4.4 && \
+  knife cookbook site install git 3.1.0 && \
+  knife cookbook site install homebrew 1.9.0 && \
+  knife cookbook site install pkgin 0.4.0 && \
+  knife cookbook site install pkgutil 0.0.3 && \
+  knife cookbook site install rbenv 1.7.1 && \
+  knife cookbook site install windows 1.34.2 && \
+  knife cookbook site install wix 1.1.0 && \
+  knife cookbook site install yum-epel 0.4.0 && \
+  knife cookbook site download 7-zip --force && \
+  for tb in maven apt build-essential git homebrew pkgin pkgutil rbenv windows wix yum-epel 7-zip; do \
+    tar xf ${tb}*.tar.gz ; \
+    rm -f ${tb}*.tar.gz ; \
+  done && \
+  echo "name 'pkgin'" >> pkgin/metadata.rb && \
+  git commit -am "HACK: Add name to pkgin's metadata" && \
+  echo "name 'pkgutil'" >> pkgutil/metadata.rb && \
+  git commit -am "HACK: Add name to pkgutil's metadata" && \
+  knife cookbook site install omnibus 1.2.4 --skip-dependencies && \
+  rm -f *.tar.gz && \
+  mkdir -p /var/tmp/coopr-build && \
+  chown -R coopr /var/tmp/coopr-build && \
+  cd /var/tmp/coopr-build && \
+  chef-solo -j /var/tmp/coopr-build/chef.json -o 'recipe[omnibus],recipe[maven]' && \
+  gem install bundler --no-rdoc --no-ri && \
+  chown -R coopr /opt && \
+  su coopr -c "bundle install --binstubs" && \
+  su coopr -c "git config --global user.email 'ops@cask.co' && git config --global user.name 'Cask Ops'" && \
+  for project in ${COOPR_BUILD_PROJECTS} ; do \
+    su coopr -c "bin/omnibus build ${project}" ; \
+    rm -rf /opt/coopr ; \
+  done

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+COOPR_DISTRIBUTIONS=${COOPR_DISTRIBUTIONS:-centos ubuntu}
+
+die() { echo "ERROR: ${@}"; exit 1; }
+
+__clean() {
+  rm -rf target
+  for __distro in ${COOPR_DISTRIBUTIONS}; do
+    __containers=$(docker ps -a | grep omnibus-coopr-${__distro} | awk '{print $1}' 2>/dev/null)
+    if [[ -n ${__containers} ]]; then
+      for __id in ${__containers}; do
+        docker stop ${__id} 2>/dev/null
+        docker rm ${__id} 2>/dev/null
+      done
+    fi
+    __images=$(docker images | grep omnibus-coopr-${__distro} | awk '{print $3' | sort -u 2>/dev/null)
+    if [[ -n ${__images} ]]; then
+      for __img in ${__images}; do
+        docker rmi ${__img} 2>/dev/null
+      done
+    fi
+  done
+  return
+}
+
+__build() {
+  mkdir -p target
+  local __failed
+  for __distro in ${COOPR_DISTRIBUTIONS}; do
+    # Create image
+    __image=omnibus-coopr-${__distro}
+    docker build -f Dockerfile-${__distro} -t ${__image} .
+    if [[ $? -eq 0 ]]; then
+      docker run -ti ${__image} -v $(pwd -P)/target:/tmp/target /bin/bash -c 'cp -f /var/tmp/coopr-build/pkg/* /tmp/target'
+      if [[ $? -eq 0 ]]; then
+        echo "Copied packages to target successfully"
+        return
+      else
+        die "Copying packages failed!"
+      fi
+    else
+      __failed+="${__distro} "
+    fi
+  done
+  if [[ -n ${__failed} ]]; then
+    die "Failed to build the following distribution packages: ${__failed}"
+  fi
+  return
+}
+
+__ret=1
+if [[ ${#} -eq 0 ]]; then
+  echo "No arguments given, running: clean build"
+  __clean && __build
+  __ret=$?
+else
+  while [[ ${#} -gt 0 ]]; then
+    case ${1} in
+      clean|build) __action=${1}; shift; __${__action}; __ret=$? ;;
+      *) die "Unrecognized parameter!" ;;
+    esac
+  done
+fi
+
+exit ${__ret}

--- a/chef.json
+++ b/chef.json
@@ -1,0 +1,7 @@
+{
+  "omnibus": {
+    "build_user": "coopr",
+    "build_dir": "/var/tmp/coopr-build",
+    "install_dir": "/opt/coopr"
+  }
+}


### PR DESCRIPTION
This allows building Coopr packages in a Docker container, versus a Virtual Machine. This has reduced overhead and a smaller on-disk footprint while building. This also allows Coopr to be built on any recent Linux machine, even on cloud instances, without requiring virtualization or a specific build platform.
