### PR TITLE
Disable git-based cache

### DIFF
--- a/omnibus.rb
+++ b/omnibus.rb
@@ -1,0 +1,2 @@
+# Disable git caching
+use_git_caching false


### PR DESCRIPTION
The git-based cache is pretty useless to us, as we build either inside a VM or a Docker container, both of which we destroy afterwards.