### PR TITLE
Replace double-brackets with test

### DIFF
--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -77,7 +77,7 @@ RUN useradd -m coopr && \
     su coopr -c "bin/omnibus build ${project}" || __failed+="${project} "; \
     rm -rf /opt/coopr ; \
   done && \
-  if [[ -n ${__failed} ]]; then \
+  if test -n "${__failed}"; then \
     echo "ERROR: Failed to build ${__failed}"; \
     exit 1; \
   fi

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -77,7 +77,7 @@ RUN useradd -m coopr && \
     su coopr -c "bin/omnibus build ${project}" || __failed+="${project} "; \
     rm -rf /opt/coopr ; \
   done && \
-  if [[ -n ${__failed} ]]; then \
+  if test -n "${__failed}"; then \
     echo "ERROR: Failed to build ${__failed}"; \
     exit 1; \
   fi


### PR DESCRIPTION
The error checking in the Dockerfile doesn't work correctly using
double brackets. Switch to using the `test` command, instead.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>