### PR TITLE
Feature/fix build deprecated cookbook

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
     - config/software/openssl.rb
     - config/software/nodejs.rb
     - config/software/nokogiri.rb
+    - config/software/bzip2.rb
     - bin/*
     - vendor/bundle/**/*
 LineLength:

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -38,12 +38,12 @@ RUN useradd -m coopr && \
   mkdir -p /var/chef/cookbooks && \
   cd /var/chef/cookbooks && \
   touch .gitignore && git init && git add .gitignore && git commit -m 'Initial commit' && \
-  knife cookbook site download 7-zip 1.0.2 --force && \
+  curl -o 7-zip-1.0.2.tar.gz -L https://supermarket.chef.io/cookbooks/7-zip/download && \
   knife cookbook site download apt 2.4.0 --force && \
   knife cookbook site download ark 0.9.0 --force && \
   knife cookbook site download build-essential 1.4.4 --force && \
-  knife cookbook site download chef_handler 1.1.6 --force && \
-  knife cookbook site download dmg 2.2.0 --force && \
+  curl -o chef_handler-1.1.6.tar.gz -L https://supermarket.chef.io/cookbooks/chef_handler/versions/1.1.6//download && \
+  curl -o dmg-2.2.0.tar.gz -L https://supermarket.chef.io/cookbooks/dmg/versions/2.2.0/download && \
   knife cookbook site download git 3.1.0 --force && \
   knife cookbook site download homebrew 1.9.0 --force && \
   knife cookbook site download java 1.21.2 --force && \

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -38,12 +38,12 @@ RUN useradd -m coopr && \
   mkdir -p /var/chef/cookbooks && \
   cd /var/chef/cookbooks && \
   touch .gitignore && git init && git add .gitignore && git commit -m 'Initial commit' && \
-  knife cookbook site download 7-zip 1.0.2 --force && \
+  curl -o 7-zip-1.0.2.tar.gz -L https://supermarket.chef.io/cookbooks/7-zip/download && \
   knife cookbook site download apt 2.4.0 --force && \
   knife cookbook site download ark 0.9.0 --force && \
   knife cookbook site download build-essential 1.4.4 --force && \
-  knife cookbook site download chef_handler 1.1.6 --force && \
-  knife cookbook site download dmg 2.2.0 --force && \
+  curl -o chef_handler-1.1.6.tar.gz -L https://supermarket.chef.io/cookbooks/chef_handler/versions/1.1.6//download && \
+  curl -o dmg-2.2.0.tar.gz -L https://supermarket.chef.io/cookbooks/dmg/versions/2.2.0/download && \
   knife cookbook site download git 3.1.0 --force && \
   knife cookbook site download homebrew 1.9.0 --force && \
   knife cookbook site download java 1.21.2 --force && \

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -24,7 +24,7 @@ default_version "1.0.6"
 dependency "zlib"
 dependency "openssl"
 
-source :url => "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz",
+source :url => "https://fossies.org/linux/misc/#{name}-#{version}.tar.gz",
        :md5 => "00b516f4704d4a7cb50a1d97e6e8e15b"
 
 relative_path "#{name}-#{version}"

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -1,0 +1,47 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Install bzip2 and its shared library, libbz2.so
+# This library object is required for building Python with the bz2 module,
+# and should be picked up automatically when building Python.
+
+name "bzip2"
+default_version "1.0.6"
+
+dependency "zlib"
+dependency "openssl"
+
+source :url => "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz",
+       :md5 => "00b516f4704d4a7cb50a1d97e6e8e15b"
+
+relative_path "#{name}-#{version}"
+
+prefix="#{install_dir}/embedded"
+libdir="#{prefix}/lib"
+
+env = {
+  "LDFLAGS" => "-L#{libdir} -I#{prefix}/include",
+  "CFLAGS" => "-L#{libdir} -I#{prefix}/include -fPIC",
+  "LD_RUN_PATH" => libdir
+}
+
+build do
+  patch :source => 'makefile_take_env_vars.patch'
+  patch :source => 'soname_install_dir.patch' if mac_os_x_mavericks?
+  command "make PREFIX=#{prefix} VERSION=#{version}", :env => env
+  command "make PREFIX=#{prefix} VERSION=#{version} -f Makefile-libbz2_so", :env => env
+  command "make install VERSION=#{version} PREFIX=#{prefix}", :env => env
+end


### PR DESCRIPTION
Updates required for the omnibus-coopr build to work again.  Just restoring functionality (no upgrades).

- [x] knife errors out with nilpointer when downloading deprecated cookbooks.  Instead, fetch them manually
- [x] bzip2 download url changed.  import bzip2 software definition from omnibus-software and [update](https://github.com/caskdata/omnibus-coopr/commit/ccaa70aeb93986c3df2cbc4f31d6d660fcd2f20f) the source url to match that of upstream master branch.

Fixed build: https://builds.cask.co/browse/COOPR-BUT2-4